### PR TITLE
Update to .NET 5, NSwag build 1132

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:2.1
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine3.13-amd64
 
-RUN curl -O -L https://github.com/RicoSuter/NSwag/releases/download/NSwag-Build-1067/NSwag.zip \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends unzip \
+RUN apk add --no-cache --update unzip curl \
+    && curl -O -L https://github.com/RicoSuter/NSwag/releases/download/NSwag-Build-1132/NSwag.zip \
     && unzip -q ./NSwag.zip -d NSwag \
-    && apt-get remove -y --purge unzip \
-    && rm -rf /var/lib/apt/lists/* \
+    && apk del unzip curl \
     && rm -f NSwag.zip
 
-ENTRYPOINT ["dotnet", "NSwag/NetCore21/dotnet-nswag.dll"]
+ENTRYPOINT ["dotnet", "NSwag/Net50/dotnet-nswag.dll"]
 CMD ["version"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 .NET Core + [NSwag](https://github.com/RicoSuter/NSwag).
 
-Built on top of mcr.microsoft.com/dotnet/core/runtime:2.1.
+Built on top of mcr.microsoft.com/dotnet/sdk:5.0-alpine3.13-amd64
 
 The container exposes [nswag as an executable](https://github.com/RicoSuter/NSwag/wiki/CommandLine).
 


### PR DESCRIPTION
We recently discovered that the base image we are using to generate our Typescript clients has several vulnerabilities.
Updating to .NET version 5.0 should get rid of these vulnerabilities (along with usage of Alpine Linux).

Unfortunately previous NSwag build don't support .NET 5 so we are going to update it as well.

Generated files look almost identical apart for version numbers (reported on top of generated files) and usage of `string` instead of the `Blob` type.
