### PR TITLE
Remove `git` from image after build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-nswa
 RUN apk add --no-cache --update unzip curl \
     && curl -O -L https://github.com/RicoSuter/NSwag/releases/download/NSwag-Build-1132/NSwag.zip \
     && unzip -q ./NSwag.zip -d NSwag \
-    && apk del unzip curl \
+    && apk del unzip curl git \
     && rm -f NSwag.zip
 
 ENTRYPOINT ["dotnet", "NSwag/Net50/dotnet-nswag.dll"]

--- a/README.md
+++ b/README.md
@@ -23,4 +23,5 @@ $ docker run -it countingup/nswag help
 
 ## Changelog
 
+ - 2022-01-19 -- Remove git from image after building
  - 2021-11-06 -- Update to Alpine 3.14 base image


### PR DESCRIPTION
The Alpine Linux package `git` comes from the Microsoft base .net image.

As of now this package has a dependency on a vulnerable package (`libexpat`).
We don't actually need to have git within this image (tested this manually by running `make ts-swagger-update` with a local nswag image) so we can remove it (and its dependencies)