### PR TITLE
Rebuild to update base image for security vulns

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $ docker run -it countingup/nswag help
 
 ## Changelog
 
+ - 2022-03-30 -- Rebuild to update base image for security vulns
  - 2022-03-23 -- Rebuild to update base image for security vulns
  - 2022-01-19 -- Remove git from image after building
  - 2022-01-17 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
This was to fix [CVE-2018-25032](https://snyk.io/vuln/SNYK-ALPINE314-ZLIB-2434419), but it also fixes [CVE-2021-37750](https://security.snyk.io/vuln/SNYK-ALPINE314-KRB5-2432003) and [CVE-2022-0778](https://security.snyk.io/vuln/SNYK-ALPINE314-LIBRETLS-2432985)