### PR TITLE
Upgrade ncurses-terminfo-base, libssl1.1 and libcrypto1.1 for security vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine3.14
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-nswag"
 
-RUN apk add --no-cache --update unzip curl busybox \
+RUN apk add --no-cache --update --upgrade ncurses-terminfo-base libssl1.1 unzip curl busybox \
     && curl -O -L https://github.com/RicoSuter/NSwag/releases/download/NSwag-Build-1132/NSwag.zip \
     && unzip -q ./NSwag.zip -d NSwag \
     && apk del unzip curl git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine3.14
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-nswag"
 
-RUN apk add --no-cache --update --upgrade ncurses-terminfo-base libssl1.1 unzip curl busybox \
+RUN apk add --no-cache --update --upgrade ncurses-terminfo-base libssl1.1 libcrypto1.1 unzip curl busybox \
     && curl -O -L https://github.com/RicoSuter/NSwag/releases/download/NSwag-Build-1132/NSwag.zip \
     && unzip -q ./NSwag.zip -d NSwag \
     && apk del unzip curl git \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ docker run -it countingup/nswag help
 
 ## Changelog
 
- - 2022-07-18 -- Rebuild to update base image for security vulns
+ - 2022-07-18 -- Upgrade ncurses-terminfo-base and libssl1.1 for security vulns
  - 2022-04-05 -- Update busybox for security vulns
  - 2022-03-30 -- Rebuild to update base image for security vulns
  - 2022-03-23 -- Rebuild to update base image for security vulns

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ $ docker run -it countingup/nswag help
 
 ## Changelog
 
+ - 2022-07-18 -- Rebuild to update base image for security vulns
  - 2022-04-05 -- Update busybox for security vulns
  - 2022-03-30 -- Rebuild to update base image for security vulns
  - 2022-03-23 -- Rebuild to update base image for security vulns

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ docker run -it countingup/nswag help
 
 ## Changelog
 
- - 2022-07-18 -- Upgrade ncurses-terminfo-base and libssl1.1 for security vulns
+ - 2022-07-18 -- Upgrade ncurses-terminfo-base, libssl1.1 and libcrypto1.1 for security vulns
  - 2022-04-05 -- Update busybox for security vulns
  - 2022-03-30 -- Rebuild to update base image for security vulns
  - 2022-03-23 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
This upgrades ncurses-terminfo-base, libssl1.1 and libcrypto1.1:
```
/ # apk add --no-cache --update --upgrade ncurses-terminfo-base libssl1.1 libcrypto1.1
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/3) Upgrading libcrypto1.1 (1.1.1n-r0 -> 1.1.1q-r0)
(2/3) Upgrading libssl1.1 (1.1.1n-r0 -> 1.1.1q-r0)
(3/3) Upgrading ncurses-terminfo-base (6.2_p20210612-r0 -> 6.2_p20210612-r1)
Executing ca-certificates-20211220-r0.trigger
OK: 42 MiB in 25 packages
```

This fixes:
 - https://www.cve.org/CVERecord?id=CVE-2022-29458 (https://security.snyk.io/vuln/SNYK-ALPINE314-NCURSES-2952571)
 -  https://www.cve.org/CVERecord?id=CVE-2022-2097 (https://security.snyk.io/vuln/SNYK-ALPINE314-OPENSSL-2941807)

