### PR TITLE
Use dotnet6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-nswag"
 
@@ -8,5 +8,5 @@ RUN apk add --no-cache --update --upgrade unzip \
     && apk del unzip curl git \
     && rm -f NSwag.zip
 
-ENTRYPOINT ["dotnet", "NSwag/Net70/dotnet-nswag.dll"]
+ENTRYPOINT ["dotnet", "NSwag/Net60/dotnet-nswag.dll"]
 CMD ["version"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ docker run -it countingup/nswag help
 ```
 
 ## Changelog
- - 2023-04-24 -- Use dotnet/sdk:6-alpine3.17
+ - 2023-04-24 -- Downgraded to dotnet/sdk:6-alpine3.17 to support Apple Silicon
  - 2023-04-18 -- Update base image to dotnet/sdk:7-alpine:3.17, NSwag to 13.18.2
  - 2023-02-10 -- Upgrade libssl1.1 for security vulns
  - 2022-09-07 -- Upgrade zlib for security vulns

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 .NET Core + [NSwag](https://github.com/RicoSuter/NSwag).
 
-Built on top of mcr.microsoft.com/dotnet/sdk:7.0-alpine3.17
+Built on top of mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17
 
 The container exposes [nswag as an executable](https://github.com/RicoSuter/NSwag/wiki/CommandLine).
 
@@ -22,6 +22,7 @@ $ docker run -it countingup/nswag help
 ```
 
 ## Changelog
+ - 2023-04-24 -- Use dotnet/sdk:6-alpine3.17
  - 2023-04-18 -- Update base image to dotnet/sdk:7-alpine:3.17, NSwag to 13.18.2
  - 2023-02-10 -- Upgrade libssl1.1 for security vulns
  - 2022-09-07 -- Upgrade zlib for security vulns


### PR DESCRIPTION
dotnet7 and Docker Mac do not work when the image is built for linux/amd64 and used on M1 Mac.

Relevant issues:
 - https://github.com/dotnet/runtime/issues/81232
 - https://gitlab.com/qemu-project/qemu/-/issues/249