### PR TITLE
Update ncurses & libssl3 to fix CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-nswag"
 
-RUN apk add --no-cache --update --upgrade unzip \
+RUN apk add --no-cache --update --upgrade unzip libssl3 ncurses \
     && curl -O -L https://github.com/RicoSuter/NSwag/releases/download/v13.18.2/NSwag.zip \
     && unzip -q ./NSwag.zip -d NSwag \
     && apk del unzip curl git \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ docker run -it countingup/nswag help
 ```
 
 ## Changelog
+ - 2023-06-07 -- Rebuild to update base image for security vulnerability (ncurses & libssl3)
  - 2023-04-24 -- Downgraded to dotnet/sdk:6-alpine3.17 to support Apple Silicon
  - 2023-04-18 -- Update base image to dotnet/sdk:7-alpine:3.17, NSwag to 13.18.2
  - 2023-02-10 -- Upgrade libssl1.1 for security vulns


### PR DESCRIPTION
1 med, 2 high:

https://security.snyk.io/vuln/SNYK-ALPINE317-OPENSSL-5438697
https://security.snyk.io/vuln/SNYK-ALPINE317-OPENSSL-5661570
https://security.snyk.io/vuln/SNYK-ALPINE317-NCURSES-5606599