### PR TITLE
Only upgrade ncurses-terminfo-base (rather than ncurses)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-nswag"
 
-RUN apk add --no-cache --update --upgrade unzip libssl3 ncurses \
+RUN apk add --no-cache --update --upgrade unzip libssl3 ncurses-terminfo-base \
     && curl -O -L https://github.com/RicoSuter/NSwag/releases/download/v13.18.2/NSwag.zip \
     && unzip -q ./NSwag.zip -d NSwag \
     && apk del unzip curl git \

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ docker run -it countingup/nswag help
 ```
 
 ## Changelog
+ - 2023-06-08 -- Just upgrade ncurses-terminfo-base, rather than ncurses
  - 2023-06-07 -- Rebuild to update base image for security vulnerability (ncurses & libssl3)
  - 2023-04-24 -- Downgraded to dotnet/sdk:6-alpine3.17 to support Apple Silicon
  - 2023-04-18 -- Update base image to dotnet/sdk:7-alpine:3.17, NSwag to 13.18.2


### PR DESCRIPTION
This amends some image build steps in https://github.com/Countingup/docker-nswag/pull/17, which added & upgraded the whole `ncurses` package in order to remedy some CVEs.

In reality, only `ncurses-terminfo-base` needed to be upgraded to `6.3_p20221119-r1`. By upgrading `ncurses`, two extra packages were added which were not previously present in the image:

```
ncurses-libs-6.3_p20221119-r1 x86_64 {ncurses} (MIT) [installed]
ncurses-6.3_p20221119-r1 x86_64 {ncurses} (MIT) [installed]
```