### PR TITLE
Rebuild image for security fixes (libcrypto3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ $ docker run -it countingup/nswag help
 ```
 
 ## Changelog
+ - 2024-01-31 -- Rebuild to update base image for security vulns (libcrypto3)
  - 2024-01-16 -- Rebuild to update base image for security vulns (libcrypto3)
  - 2023-07-19 -- Rebuild to update base image for security vulns (libcrypto3)
  - 2023-06-08 -- Just upgrade ncurses-terminfo-base, rather than ncurses


### PR DESCRIPTION
Fixes CVE-2023-6237 and CVE-2024-0727 in openssl/libcrypto3 ([snyk](https://app.snyk.io/org/countingup/project/e67d0807-2603-4ae1-a103-4ecf3bfe9a94))