### PR TITLE
Update base image & NSwag to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-nswag"
 
 RUN apk add --no-cache --update --upgrade unzip libssl3 ncurses-terminfo-base busybox krb5-libs \
-    && curl -O -L https://github.com/RicoSuter/NSwag/releases/download/v13.18.2/NSwag.zip \
+    && curl -O -L https://github.com/RicoSuter/NSwag/releases/download/v14.6.3/NSwag.zip \
     && unzip -q ./NSwag.zip -d NSwag \
     && apk del unzip curl git \
     && rm -f NSwag.zip
 
-ENTRYPOINT ["dotnet", "NSwag/Net60/dotnet-nswag.dll"]
+ENTRYPOINT ["dotnet", "NSwag/Net100/dotnet-nswag.dll"]
 CMD ["version"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 .NET Core + [NSwag](https://github.com/RicoSuter/NSwag).
 
-Built on top of mcr.microsoft.com/dotnet/sdk:6.0-alpine3.17
+Built on top of mcr.microsoft.com/dotnet/sdk:10.0-alpine3.23
 
 The container exposes [nswag as an executable](https://github.com/RicoSuter/NSwag/wiki/CommandLine).
 
@@ -22,6 +22,7 @@ $ docker run -it countingup/nswag help
 ```
 
 ## Changelog
+ - 2026-03-09 -- Update base image to dotnet/sdk:10.0-alpine3.23, NSwag to v14.6.3
  - 2024-11-12 -- Manually updated `krb5-libs` to fix security vulnerability
  - 2024-06-19 -- Manually updated `busybox` to fix security vulnerability
  - 2024-01-31 -- Rebuild to update base image for security vulns (libcrypto3)


### PR DESCRIPTION
Updated from a rather old alpine base image.

Also updated to latest NSwag - see https://github.com/RicoSuter/NSwag/releases/tag/v14.0.0 for breaking changes.